### PR TITLE
add routing key to headers interface

### DIFF
--- a/lib/hot_bunnies/queue.rb
+++ b/lib/hot_bunnies/queue.rb
@@ -115,6 +115,10 @@ module HotBunnies
       def delivery_tag
         @envelope.delivery_tag
       end
+
+      def routing_key
+        @envelope.routing_key
+      end
     end
 
     module Subscriber


### PR DESCRIPTION
Hi

I've added routing_key to the Headers class. It's useful to be able to grab that when deciding what to do with a message. Any issues with that?
