### PR TITLE
Selecting the right overloaded Executor#submit

### DIFF
--- a/lib/hot_bunnies/consumers.rb
+++ b/lib/hot_bunnies/consumers.rb
@@ -102,12 +102,13 @@ module HotBunnies
     def initialize(channel, opts, callback, executor)
       super(channel, callback)
       @executor = executor
-      @opts     = opts
+      @executor_submit = executor.java_method(:submit, [JavaConcurrent::Runnable.java_class])
+      @opts = opts
     end
 
     def deliver(headers, message)
       unless @executor.shutdown?
-        @executor.submit do
+        @executor_submit.call do
           begin
             callback(headers, message)
           rescue Exception => e

--- a/lib/hot_bunnies/juc.rb
+++ b/lib/hot_bunnies/juc.rb
@@ -1,5 +1,6 @@
 module JavaConcurrent
   java_import 'java.lang.Thread'
+  java_import 'java.lang.Runnable'
   java_import 'java.lang.InterruptedException'
   java_import 'java.util.concurrent.Executors'
   java_import 'java.util.concurrent.LinkedBlockingQueue'


### PR DESCRIPTION
JRuby 1.7.x is more aggressive in warning when there is not enough type information and it has to pick an overloaded implementation. This avoids the warning by selecting the method explicitly. Could have used #java_send too, but that would be noisier. Executor#execute works too, but it prints warnings in the tests that I don't want to have to understand why right now.

This fixes #14
