### PR TITLE
Add support for ConfirmListener callbacks via Channel#on_confirm

### DIFF
--- a/lib/march_hare/channel.rb
+++ b/lib/march_hare/channel.rb
@@ -804,15 +804,41 @@ module MarchHare
     def on_return(&block)
       self.add_return_listener(BlockReturnListener.from(block))
     end
+    
+    # Defines a publisher confirm handler
+    def on_confirm(&block)
+      self.add_confirm_listener(BlockConfirmListener.from(block))
+    end
 
     def method_missing(selector, *args)
       @delegate.__send__(selector, *args)
     end
-
+    
 
     #
     # Implementation
     #
+    
+    # @private
+    class BlockConfirmListener
+      include com.rabbitmq.client.ConfirmListener
+      
+      def self.from(block)
+        new(block)
+      end
+
+      def initialize(block)
+        @block = block
+      end
+
+      def handleAck(delivery_tag, multiple)
+        @block.call(:ack, delivery_tag, multiple)
+      end
+
+      def handleNack(delivery_tag, multiple)
+        @block.call(:nack, delivery_tag, multiple)
+      end
+    end
 
     # @private
     class BlockReturnListener

--- a/spec/higher_level_api/integration/publisher_confirmations_spec.rb
+++ b/spec/higher_level_api/integration/publisher_confirmations_spec.rb
@@ -28,4 +28,19 @@ describe "Any channel" do
 
     true.should be_true
   end
+  
+  it "can receive publisher confirmation acks" do
+    got_ack = false
+    ch = connection.create_channel
+    q  = ch.queue("", :exclusive => true)
+
+    ch.confirm_select
+    ch.on_confirm { |type, seq, multiple| got_ack = (type ==:ack) }
+    
+    ch.default_exchange.publish("", :routing_key => q.name)
+
+    ch.wait_for_confirms(40)
+
+    got_ack.should be_true
+  end
 end


### PR DESCRIPTION
Hello, just adding support for an on_confirm listener to handle publish confirmation ack/nack messages. 
