### PR TITLE
intercept java.net.SocketException

### DIFF
--- a/lib/march_hare/exceptions.rb
+++ b/lib/march_hare/exceptions.rb
@@ -97,6 +97,8 @@ module MarchHare
   class Exceptions
     def self.convert(e, unwrap_io_exception = true)
       case e
+      when java.net.SocketException then
+        ChannelAlreadyClosed.new(e.message)
       when java.io.IOException then
         c = e.cause
 


### PR DESCRIPTION
I'm really not sure if this is the right way to fix the problem I encountered, but this small patch does the trick for me. I won't be disapointed if you reject it and handle this another way :-)

With this out of the way, here's a description of the problem:

When going through this block of code under jruby 1.7.11 with java7:
https://github.com/elasticsearch/logstash/blob/master/lib/logstash/outputs/rabbitmq/march_hare.rb#L47-L60

... logstash crashes with the following error:

```
TypeError: exception class/object expected
                convert_and_reraise at /home/marc/src/logstash/vendor/bundle/jruby/1.9/gems/march_hare-2.1.2-java/lib/march_hare/exceptions.rb:122
  converting_rjc_exceptions_to_ruby at /home/marc/src/logstash/vendor/bundle/jruby/1.9/gems/march_hare-2.1.2-java/lib/march_hare/channel.rb:962
  converting_rjc_exceptions_to_ruby at /home/marc/src/logstash/vendor/bundle/jruby/1.9/gems/march_hare-2.1.2-java/lib/march_hare/channel.rb:960
                      basic_publish at /home/marc/src/logstash/vendor/bundle/jruby/1.9/gems/march_hare-2.1.2-java/lib/march_hare/channel.rb:586
                            publish at /home/marc/src/logstash/vendor/bundle/jruby/1.9/gems/march_hare-2.1.2-java/lib/march_hare/exchange.rb:77
                 publish_serialized at /home/marc/src/logstash/lib/logstash/outputs/rabbitmq/march_hare.rb:41
                               call at org/jruby/RubyProc.java:271
                             encode at /home/marc/src/logstash/lib/logstash/codecs/json.rb:45
                            receive at /home/marc/src/logstash/lib/logstash/outputs/rabbitmq/march_hare.rb:31
                             handle at /home/marc/src/logstash/lib/logstash/outputs/base.rb:86
                         initialize at (eval):19
                               call at org/jruby/RubyProc.java:271
                             output at /home/marc/src/logstash/lib/logstash/pipeline.rb:266
                       outputworker at /home/marc/src/logstash/lib/logstash/pipeline.rb:225
                      start_outputs at /home/marc/src/logstash/lib/logstash/pipeline.rb:152
```

This error happens when logstash has an open connection with rabbitmq, but rabbitmq is refusing new messages (because of a diskfull), and rabbitmq gets restarted at this moment.

From what I figured out, this statement:
https://github.com/ruby-amqp/march_hare/blob/master/lib/march_hare/exceptions.rb#L101
returns `nil` in this case, which doesn't go well when passed through the rest of the code, and explains the `TypeError` above. Bypassing the `java.io.IOException` case as this patch does raises a `MarchHare::Exception`, which is then caught by logstash and allows it to retry connecting to rabbitmq in a loop instead of crashing.

Thanks !
