### PR TITLE
Unregister by consumer tag, not by consumer instance

### DIFF
--- a/lib/march_hare/channel.rb
+++ b/lib/march_hare/channel.rb
@@ -268,7 +268,7 @@ module MarchHare
     def recover_consumers
       @consumers.values.each do |c|
         begin
-          self.unregister_consumer(c)
+          self.unregister_consumer(c.consumer_tag)
           c.recover_from_network_failure
         rescue Exception => e
           # TODO: logger


### PR DESCRIPTION
Currently, consumer unregistration doesn't work properly during automatic recovery. `Channel#recover_consumers` passes the consumer instance, rather than the consumer tag to `unregister_consumer`, which expects a consumer tag.
