### PR TITLE
Add missing exception class

### DIFF
--- a/lib/march_hare/exceptions.rb
+++ b/lib/march_hare/exceptions.rb
@@ -89,7 +89,8 @@ module MarchHare
   class ChannelAlreadyClosed < Exception
   end
 
-
+  class ConnectionForced < Exception
+  end
 
   # Converts RabbitMQ Java client exceptions
   #


### PR DESCRIPTION
The `ConnectionForced` exception can by raised on line 141, but the class itself is not defined in the codebase. This PR simply adds the class definition to `MarchHare::Exceptions`.
