### PR TITLE
Prime the delivery_tag when a Headers instance is created

### DIFF
--- a/lib/march_hare/metadata.rb
+++ b/lib/march_hare/metadata.rb
@@ -7,6 +7,11 @@ module MarchHare
       @consumer_tag = consumer_tag
       @envelope     = envelope
       @properties   = properties
+
+      # Prime the delivery tag when the instance is created. If #delivery_tag is first
+      # called after a recovery, then it'll fail to mismatch and will allow an invalid
+      # ack/nack, which will cause the channel to unexpectedly close
+      @delivery_tag = delivery_tag
     end
 
     def ack(options={})


### PR DESCRIPTION
Applications that fail to call `Headers#delivery` tag until `ack`/`nack` time (that is, perhaps after a network recovery) will have the wrong recoveries_count in their delivery tag. That is:
- A message is received (`Channel#@recoveries_count` is 0) with delivery tag 8
- A network recovery happens and increments `Channel#@recoveries_count` to 1
- headers.ack is called, which calls `#delivery_tag`, which determines that the correct version for these headers is `delivery-tag=8, recoveries_count=1` rather than `delivery-tag=8, recoveries_count=0`. This causes march_hare to attempt to ack the message even though it was delivered on the recoveries_count = 0 channel, which causes RMQ to reject the ack and close the freshly-opened recoveries=1 channel.

This PR fixes that by simply priming the `@delivery_tag` ivar when the Headers instance is created, so that it will always match the correct `@recoveries_count`.
