### PR TITLE
add support for ssl connection using p12 file

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -7,6 +7,11 @@ module MarchHare
   java_import com.rabbitmq.client.ConnectionFactory
   java_import com.rabbitmq.client.Connection
   java_import com.rabbitmq.client.BlockedListener
+  java_import com.rabbitmq.client.NullTrustManager
+
+  java_import javax.net.ssl.SSLContext
+  java_import javax.net.ssl.KeyManagerFactory
+  java_import java.security.KeyStore
 
   # Connection to a RabbitMQ node.
   #
@@ -64,6 +69,32 @@ module MarchHare
       when String then
         if options[:trust_manager]
           cf.use_ssl_protocol(tls, options[:trust_manager])
+        elsif options[:keycert] && options[:certificate_password]
+          sslContext = SSLContext.get_instance(tls)
+          certificate_password = options[:certificate_password].to_java.to_char_array
+          begin
+            input_stream = File.new(options[:keycert]).to_inputstream
+            key_store = KeyStore.get_instance('PKCS12')
+            key_store.load(input_stream, certificate_password)
+
+            key_manager_factory = KeyManagerFactory.get_instance("SunX509")
+            key_manager_factory.init(key_store, certificate_password)
+
+            key_managers =  key_manager_factory.get_key_managers
+
+            sslContext.init(key_managers, [NullTrustManager.new].to_java('javax.net.ssl.TrustManager'), nil)
+
+            cf.use_ssl_protocol(sslContext)
+          # catch all exceptions from java
+          rescue Java::JavaLang::Exception => e
+            message = e.message
+            message << "\n"
+            message << e.backtrace.join("\n")
+
+            raise SSLContextException.new(message)
+          ensure
+            input_stream.close if input_stream
+          end  
         else
           cf.use_ssl_protocol(tls)
         end
@@ -72,6 +103,11 @@ module MarchHare
 
       new(cf, options)
     end
+
+
+    class SSLContextException < StandardError
+    end
+
 
     # @return [Array<MarchHare::Channel>] Channels opened on this connection
     attr_reader :channels

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -69,11 +69,11 @@ module MarchHare
       when String then
         if options[:trust_manager]
           cf.use_ssl_protocol(tls, options[:trust_manager])
-        elsif options[:keycert] && options[:certificate_password]
+        elsif (key_cert = tls_key_certificate_path_from(options)) && (key_cert_password = tls_key_certificate_password_from(options))
           sslContext = SSLContext.get_instance(tls)
-          certificate_password = options[:certificate_password].to_java.to_char_array
+          certificate_password = key_cert_password.to_java.to_char_array
           begin
-            input_stream = File.new(options[:keycert]).to_inputstream
+            input_stream = File.new(key_cert).to_inputstream
             key_store = KeyStore.get_instance('PKCS12')
             key_store.load(input_stream, certificate_password)
 
@@ -479,6 +479,16 @@ module MarchHare
         return Proc.new { MarchHare::ThreadPools.fixed_of_size(n) }
       end
     end
+
+    # @private
+    def tls_key_certificate_path_from(opts)
+      opts[:tls_key_cert] || opts[:ssl_key_cert] || opts[:tls_key_cert_path] || opts[:ssl_key_cert_path] || opts[:tls_key_certificate_path] || opts[:ssl_key_certificate_path]
+    end
+    
+    # @private
+    def tls_key_certificate_password_from(opts)
+      opts[:cert_password] || opts[:certificate_password]
+    end  
 
     # Ruby blocks-based BlockedListener that handles
     # connection.blocked and connection.unblocked.


### PR DESCRIPTION
Add support to allow SSL/TLS connection over AMQP channel using p12 configuration file. Adding the following options when calling **MarchHare.connect** to enable ssl/tls connection

**tls/ssl** The name of the protocal. For instance: TLSv1.2 etc.
**keycert** The location of p12 file(PKCS #12 store), which contains both the key and certificate for the clint
**password** The password of the p12 file provided above
