### PR TITLE
Throw Ruby exceptions for exchange declaration and binding errors

### DIFF
--- a/lib/march_hare/channel.rb
+++ b/lib/march_hare/channel.rb
@@ -415,7 +415,9 @@ module MarchHare
     # @return RabbitMQ response
     # @see http://rubymarchhare.info/articles/echanges.html Exchanges and Publishing guide
     def exchange_declare(name, type, durable = false, auto_delete = false, internal = false, arguments = nil)
-      @delegate.exchange_declare(name, type, durable, auto_delete, internal, arguments)
+      converting_rjc_exceptions_to_ruby do
+        @delegate.exchange_declare(name, type, durable, auto_delete, internal, arguments)
+      end
     end
 
     # Binds an exchange to another exchange using exchange.bind method (RabbitMQ extension)
@@ -430,7 +432,9 @@ module MarchHare
     # @see http://rubymarchhare.info/articles/extensions.html RabbitMQ extensions guide
     # @see http://rubymarchhare.info/articles/bindings.html Bindings guide
     def exchange_bind(destination, source, routing_key, arguments = nil)
-      @delegate.exchange_bind(destination, source, routing_key, arguments)
+      converting_rjc_exceptions_to_ruby do
+        @delegate.exchange_bind(destination, source, routing_key, arguments)
+      end
     end
 
     # Unbinds an exchange from another exchange using exchange.unbind method (RabbitMQ extension)
@@ -445,7 +449,9 @@ module MarchHare
     # @see http://rubymarchhare.info/articles/extensions.html RabbitMQ extensions guide
     # @see http://rubymarchhare.info/articles/bindings.html Bindings guide
     def exchange_unbind(destination, source, routing_key, arguments = nil)
-      @delegate.exchange_unbind(destination, source, routing_key, arguments)
+      converting_rjc_exceptions_to_ruby do
+        @delegate.exchange_unbind(destination, source, routing_key, arguments)
+      end
     end
 
     # @endgroup

--- a/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require "rabbitmq/http/client"
+
+describe "Exchange declaration error handling" do
+  let(:connection) {}
+  let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
+
+  def close_all_connections!
+    http_client.list_connections.each do |conn_info|
+      http_client.close_connection(conn_info.name)
+    end
+  end
+
+  def with_open(c = MarchHare.connect(:network_recovery_interval => 5), &block)
+    begin
+      block.call(c)
+    ensure
+      c.close if c.open?
+    end
+  end
+
+  #
+  # Examples
+  #
+
+  it "does not leak Java exceptions" do
+    with_open do |c|
+      ch = c.create_channel
+      close_all_connections!
+      sleep 0.1
+      expect(c).not_to be_open
+      expect { ch.direct("direct.exchange.exception.test", :durable => false) }.to raise_exception(MarchHare::ChannelAlreadyClosed)
+    end
+  end
+end

--- a/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
@@ -23,11 +23,11 @@ describe "Exchange declaration error handling" do
   # Examples
   #
 
-  it "does not leak Java exceptions" do
+  it "does not throw Java exceptions" do
     with_open do |c|
       ch = c.create_channel
       close_all_connections!
-      sleep 0.1
+      sleep 0.5
       expect(c).not_to be_open
       expect { ch.direct("direct.exchange.exception.test", :durable => false) }.to raise_exception(MarchHare::ChannelAlreadyClosed)
     end


### PR DESCRIPTION
This commit makes sure that
  * Channel#exchange_declare
  * Channel#exchange_bind
  * Channel#exchange_unbind
raise Ruby exceptions instead of their "native" Java counterparts.