### PR TITLE
apply custom consumer tag to consumer if supplied

### DIFF
--- a/lib/march_hare/channel.rb
+++ b/lib/march_hare/channel.rb
@@ -614,10 +614,14 @@ module MarchHare
       end
     end
 
-    def basic_consume(queue, auto_ack, consumer)
+    def basic_consume(queue, auto_ack, consumer_tag=nil, consumer)
       consumer.auto_ack = auto_ack
       tag = converting_rjc_exceptions_to_ruby do
-        @delegate.basic_consume(queue, auto_ack, consumer)
+        if consumer_tag
+          @delegate.basic_consume(queue, auto_ack, consumer_tag, consumer)
+        else
+          @delegate.basic_consume(queue, auto_ack, consumer)
+        end
       end
       self.register_consumer(tag, consumer)
 

--- a/lib/march_hare/consumers/base.rb
+++ b/lib/march_hare/consumers/base.rb
@@ -84,7 +84,7 @@ module MarchHare
     def recover_from_network_failure
       @terminated.set(false)
       @cancelled.set(false)
-      @consumer_tag = @channel.basic_consume(@queue.name, @auto_ack, self)
+      @consumer_tag = @channel.basic_consume(@queue.name, @auto_ack, @consumer_tag, self)
 
       @consumer_tag
     end

--- a/lib/march_hare/queue.rb
+++ b/lib/march_hare/queue.rb
@@ -180,7 +180,7 @@ module MarchHare
     end
 
     def subscribe_with(consumer, opts = {})
-      @consumer_tag     = @channel.basic_consume(@name, !(opts[:ack] || opts[:manual_ack]), consumer)
+      @consumer_tag = @channel.basic_consume(@name, !(opts[:ack] || opts[:manual_ack]), opts[:consumer_tag], consumer)
       consumer.consumer_tag = @consumer_tag
 
       @default_consumer = consumer

--- a/spec/higher_level_api/integration/basic_consume_spec.rb
+++ b/spec/higher_level_api/integration/basic_consume_spec.rb
@@ -25,6 +25,25 @@ describe "A consumer" do
     expect(consumer).not_to be_active
     expect(consumer).to be_cancelled
   end
+
+  it "has a consumer_tag" do
+    ch       = connection.create_channel
+    q        = ch.queue("", :exclusive => true)
+
+    consumer1 = q.subscribe(:blocking => false) { |_, _| nil }
+
+    sleep(1.0)
+    expect(consumer1.consumer_tag).to match(/^amq.ctag/)
+    consumer.cancel
+
+    custom_consumer_tag = "unique_consumer_tag_#{rand(1_000)}"
+    consumer2 = q.subscribe(:consumer_tag => custom_consumer_tag, :blocking => false) { |_, _| nil }
+
+    expect(consumer2.consumer_tag).to eq(custom_consumer_tag)
+
+    consumer.cancel
+    consumer2.cancel
+  end
 end
 
 

--- a/spec/higher_level_api/integration/basic_consume_spec.rb
+++ b/spec/higher_level_api/integration/basic_consume_spec.rb
@@ -34,14 +34,13 @@ describe "A consumer" do
 
     sleep(1.0)
     expect(consumer1.consumer_tag).to match(/^amq.ctag/)
-    consumer.cancel
+    consumer1.cancel
 
     custom_consumer_tag = "unique_consumer_tag_#{rand(1_000)}"
     consumer2 = q.subscribe(:consumer_tag => custom_consumer_tag, :blocking => false) { |_, _| nil }
 
     expect(consumer2.consumer_tag).to eq(custom_consumer_tag)
 
-    consumer.cancel
     consumer2.cancel
   end
 end


### PR DESCRIPTION
This fixes #92 and creates the consumer with a custom consumer_tag if one is supplied, otherwise the previous behaviour of using the auto-generated one is maintained.

Some Notes:
* I placed the consumer_tag as third parameter in `Channel#basic_consume` to keep the interface the same as the delegated java method.
* in the `recover_from_network_failure` case I recreate a consumer with the same consumer tag - so it would use a custom supplied one. I'm not sure in which cases this method is exaclty called and if there are any edge cases to consider when reusing the same consumer_tag.
* I wasn't entirely sure where to put the specs for this, but the basic_consume_specs seemed like a good place.