### PR TITLE
Modernize rspec usage and fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debug/*
 deploy.docs.sh
 .ruby-version
 .idea
+spec/examples.txt

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
--cb
+--backtrace
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'rake', ">= 10.0.0"
 
 group :test do
-  gem "rspec", "~> 3.1.0"
+  gem "rspec", "~> 3.5"
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ See [ChangeLog.md](ChangeLog.md).
 CI is hosted by [travis-ci.org](http://travis-ci.org)
 
 
+## Testing
+
+You'll need a running rabbitmq instance on your local machine to run the specs.
+
+To boot one via docker you can use:
+
+```bash
+$ docker run -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+```
+
+And then you can run the specs using `rspec`:
+
+```bash
+$ bundle exec rspec
+```
+
+
 ## License
 
 MIT, see LICENSE in the repository root

--- a/lib/march_hare/channel.rb
+++ b/lib/march_hare/channel.rb
@@ -226,19 +226,19 @@ module MarchHare
     # Recovery feature.
     #
     def recover_prefetch_setting
-      basic_qos(@prefetch_count) if @prefetch_count
+      basic_qos(@prefetch_count) if defined?(@prefetch_count) && @prefetch_count
     end
 
     # Recovers publisher confirms mode. Used by the Automatic Network Failure
     # Recovery feature.
     def recover_confirm_mode
-      confirm_select if @confirm_mode
+      confirm_select if defined?(@confirm_mode) && @confirm_mode
     end
 
     # Recovers transaction mode. Used by the Automatic Network Failure
     # Recovery feature.
     def recover_tx_mode
-      tx_select if @tx_mode
+      tx_select if defined?(@tx_mode) && @tx_mode
     end
 
     # Recovers exchanges. Used by the Automatic Network Failure

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -522,7 +522,7 @@ module MarchHare
 
     # @private
     def maybe_shut_down_executor
-      @executor.shutdown if @executor
+      @executor.shutdown if defined?(@executor) && @executor
     end
 
     # Makes it easier to construct executor factories.

--- a/spec/higher_level_api/integration/alternate_exchanges_spec.rb
+++ b/spec/higher_level_api/integration/alternate_exchanges_spec.rb
@@ -1,4 +1,4 @@
-describe "Any exchange" do
+RSpec.describe "Any exchange" do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/alternate_exchanges_spec.rb
+++ b/spec/higher_level_api/integration/alternate_exchanges_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "Any exchange" do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/basic_ack_spec.rb
+++ b/spec/higher_level_api/integration/basic_ack_spec.rb
@@ -1,4 +1,4 @@
-describe MarchHare::Channel, "#ack" do
+RSpec.describe MarchHare::Channel, "#ack" do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/basic_ack_spec.rb
+++ b/spec/higher_level_api/integration/basic_ack_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe MarchHare::Channel, "#ack" do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/basic_cancel_spec.rb
+++ b/spec/higher_level_api/integration/basic_cancel_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe 'A consumer' do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/basic_cancel_spec.rb
+++ b/spec/higher_level_api/integration/basic_cancel_spec.rb
@@ -1,4 +1,4 @@
-describe 'A consumer' do
+RSpec.describe 'A consumer' do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/basic_consume_spec.rb
+++ b/spec/higher_level_api/integration/basic_consume_spec.rb
@@ -1,4 +1,4 @@
-describe "A consumer" do
+RSpec.describe "A consumer" do
   let(:connection) { MarchHare.connect }
 
   after :each do
@@ -43,7 +43,7 @@ describe "A consumer" do
 end
 
 
-describe "Multiple non-exclusive consumers per queue" do
+RSpec.describe "Multiple non-exclusive consumers per queue" do
   let(:connection) { MarchHare.connect }
 
   after :each do
@@ -97,7 +97,7 @@ describe "Multiple non-exclusive consumers per queue" do
 end
 
 
-describe "A consumer" do
+RSpec.describe "A consumer" do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/basic_consume_spec.rb
+++ b/spec/higher_level_api/integration/basic_consume_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-
-
 describe "A consumer" do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/basic_reject_spec.rb
+++ b/spec/higher_level_api/integration/basic_reject_spec.rb
@@ -1,4 +1,4 @@
-describe MarchHare::Channel, "#reject" do
+RSpec.describe MarchHare::Channel, "#reject" do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/basic_reject_spec.rb
+++ b/spec/higher_level_api/integration/basic_reject_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe MarchHare::Channel, "#reject" do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -1,6 +1,6 @@
 require "rabbitmq/http/client"
 
-describe "Connection recovery" do
+RSpec.describe "Connection recovery" do
   let(:connection)  {  }
   let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
   let(:amqp_uri) { "amqp://localhost:5672/%2F" }

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rabbitmq/http/client"
 
 describe "Connection recovery" do

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 java_import java.util.concurrent.CountDownLatch
 java_import java.util.concurrent.TimeUnit
 

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -1,7 +1,7 @@
 java_import java.util.concurrent.CountDownLatch
 java_import java.util.concurrent.TimeUnit
 
-describe "MarchHare.connect" do
+RSpec.describe "MarchHare.connect" do
 
   #
   # Examples
@@ -128,7 +128,7 @@ describe "MarchHare.connect" do
 end
 
 
-describe "MarchHare::Session#start" do
+RSpec.describe "MarchHare::Session#start" do
   it "is a no-op added for better compatibility with Bunny and to guard non-idempotent AMQConnection#start" do
     c = MarchHare.connect
     100.times do

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "MarchHare.connect" do
       calls += 1
       MarchHare::JavaConcurrent::Executors.new_cached_thread_pool
     end
-    c1 = MarchHare.connect(:executor_factory => factory)
+    c1 = MarchHare.connect(:executor_factory => factory, :network_recovery_interval => 0)
     c1.close
     c1.automatically_recover
     c1.close
@@ -68,7 +68,7 @@ RSpec.describe "MarchHare.connect" do
 
 
   it "lets you specify fixed thread pool size" do
-    c = MarchHare.connect(:thread_pool_size => 20)
+    c = MarchHare.connect(:thread_pool_size => 20, :network_recovery_interval => 0)
     expect(c).to be_connected
     c.close
     expect(c).not_to be_connected
@@ -78,7 +78,7 @@ RSpec.describe "MarchHare.connect" do
   end
 
   it "lets you specify multiple hosts" do
-    c = MarchHare.connect(:hosts => ["127.0.0.1"])
+    c = MarchHare.connect(:hosts => ["127.0.0.1"], :network_recovery_interval => 0)
     expect(c).to be_connected
     c.close
     expect(c).not_to be_connected

--- a/spec/higher_level_api/integration/consumer_cancellation_notification_spec.rb
+++ b/spec/higher_level_api/integration/consumer_cancellation_notification_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Non-blocking consumer" do
     ch2 = connection.create_channel
     q   = ch2.queue(queue_name, :auto_delete => true)
 
-    q.subscribe(:on_cancellation => Proc.new { |ch, consumer| cancelled = true }) do |_, _|
+    q.subscribe(:on_cancellation => Proc.new { |_ch, consumer| cancelled = true }) do |_, _|
       # no-op
     end
 
@@ -54,7 +54,7 @@ RSpec.describe "Blocking consumer" do
       ch2 = connection.create_channel
       q   = ch2.queue(queue_name, :auto_delete => true)
 
-      q.subscribe(:on_cancellation => Proc.new { |ch, consumer| cancelled = true }, :block => true) do |_, _|
+      q.subscribe(:on_cancellation => Proc.new { |_ch, consumer| cancelled = true }, :block => true) do |_, _|
         # no-op
       end
     end

--- a/spec/higher_level_api/integration/consumer_cancellation_notification_spec.rb
+++ b/spec/higher_level_api/integration/consumer_cancellation_notification_spec.rb
@@ -1,4 +1,4 @@
-describe "Non-blocking consumer" do
+RSpec.describe "Non-blocking consumer" do
   let(:connection) do
     MarchHare.connect
   end
@@ -35,7 +35,7 @@ describe "Non-blocking consumer" do
 end
 
 
-describe "Blocking consumer" do
+RSpec.describe "Blocking consumer" do
   let(:connection) do
     MarchHare.connect
   end

--- a/spec/higher_level_api/integration/consumer_cancellation_notification_spec.rb
+++ b/spec/higher_level_api/integration/consumer_cancellation_notification_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "Non-blocking consumer" do
   let(:connection) do
     MarchHare.connect

--- a/spec/higher_level_api/integration/exchange_bind_spec.rb
+++ b/spec/higher_level_api/integration/exchange_bind_spec.rb
@@ -1,4 +1,4 @@
-describe MarchHare::Exchange do
+RSpec.describe MarchHare::Exchange do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/exchange_bind_spec.rb
+++ b/spec/higher_level_api/integration/exchange_bind_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe MarchHare::Exchange do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rabbitmq/http/client"
 
 describe "Exchange declaration error handling" do

--- a/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declaration_failure_spec.rb
@@ -1,6 +1,6 @@
 require "rabbitmq/http/client"
 
-describe "Exchange declaration error handling" do
+RSpec.describe "Exchange declaration error handling" do
   let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
 
   def close_all_connections!

--- a/spec/higher_level_api/integration/exchange_declare_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declare_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "Direct exchange" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }

--- a/spec/higher_level_api/integration/exchange_declare_spec.rb
+++ b/spec/higher_level_api/integration/exchange_declare_spec.rb
@@ -1,4 +1,4 @@
-describe "Direct exchange" do
+RSpec.describe "Direct exchange" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 
@@ -25,7 +25,7 @@ end
 
 
 
-describe "Fanout exchange" do
+RSpec.describe "Fanout exchange" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 
@@ -54,7 +54,7 @@ end
 
 
 
-describe "Topic exchange" do
+RSpec.describe "Topic exchange" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 
@@ -83,7 +83,7 @@ end
 
 
 
-describe "Headers exchange" do
+RSpec.describe "Headers exchange" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 
@@ -113,7 +113,7 @@ end
 
 
 
-describe "Internal exchange" do
+RSpec.describe "Internal exchange" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 

--- a/spec/higher_level_api/integration/exchange_unbind_spec.rb
+++ b/spec/higher_level_api/integration/exchange_unbind_spec.rb
@@ -1,4 +1,4 @@
-describe MarchHare::Exchange do
+RSpec.describe MarchHare::Exchange do
   let(:connection) { MarchHare.connect }
 
   after :each do

--- a/spec/higher_level_api/integration/exchange_unbind_spec.rb
+++ b/spec/higher_level_api/integration/exchange_unbind_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe MarchHare::Exchange do
   let(:connection) { MarchHare.connect }
 

--- a/spec/higher_level_api/integration/merry_go_round_spec.rb
+++ b/spec/higher_level_api/integration/merry_go_round_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "A message that is proxied by multiple intermediate consumers" do
   let(:c1) do
     MarchHare.connect

--- a/spec/higher_level_api/integration/merry_go_round_spec.rb
+++ b/spec/higher_level_api/integration/merry_go_round_spec.rb
@@ -1,4 +1,4 @@
-describe "A message that is proxied by multiple intermediate consumers" do
+RSpec.describe "A message that is proxied by multiple intermediate consumers" do
   let(:c1) do
     MarchHare.connect
   end

--- a/spec/higher_level_api/integration/message_metadata_access_spec.rb
+++ b/spec/higher_level_api/integration/message_metadata_access_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "A consumer" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }

--- a/spec/higher_level_api/integration/message_metadata_access_spec.rb
+++ b/spec/higher_level_api/integration/message_metadata_access_spec.rb
@@ -1,4 +1,4 @@
-describe "A consumer" do
+RSpec.describe "A consumer" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 

--- a/spec/higher_level_api/integration/publisher_confirmations_spec.rb
+++ b/spec/higher_level_api/integration/publisher_confirmations_spec.rb
@@ -1,4 +1,4 @@
-describe "Any channel" do
+RSpec.describe "Any channel" do
 
   #
   # Environment

--- a/spec/higher_level_api/integration/publisher_confirmations_spec.rb
+++ b/spec/higher_level_api/integration/publisher_confirmations_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "Any channel" do
 
   #

--- a/spec/higher_level_api/integration/queue_bind_spec.rb
+++ b/spec/higher_level_api/integration/queue_bind_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-
-
 describe "A queue" do
 
   #

--- a/spec/higher_level_api/integration/queue_bind_spec.rb
+++ b/spec/higher_level_api/integration/queue_bind_spec.rb
@@ -1,4 +1,4 @@
-describe "A queue" do
+RSpec.describe "A queue" do
 
   #
   # Environment

--- a/spec/higher_level_api/integration/queue_declare_spec.rb
+++ b/spec/higher_level_api/integration/queue_declare_spec.rb
@@ -1,4 +1,4 @@
-describe "Queue" do
+RSpec.describe "Queue" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }
 

--- a/spec/higher_level_api/integration/queue_declare_spec.rb
+++ b/spec/higher_level_api/integration/queue_declare_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-
-
 describe "Queue" do
   let(:connection) { MarchHare.connect }
   let(:channel)    { connection.create_channel }

--- a/spec/higher_level_api/integration/queue_delete_spec.rb
+++ b/spec/higher_level_api/integration/queue_delete_spec.rb
@@ -1,4 +1,4 @@
-describe "Queue" do
+RSpec.describe "Queue" do
 
   #
   # Environment

--- a/spec/higher_level_api/integration/queue_delete_spec.rb
+++ b/spec/higher_level_api/integration/queue_delete_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-
-
 describe "Queue" do
 
   #

--- a/spec/higher_level_api/integration/queue_purge_spec.rb
+++ b/spec/higher_level_api/integration/queue_purge_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-
-
 describe "Any queue" do
 
   #

--- a/spec/higher_level_api/integration/queue_purge_spec.rb
+++ b/spec/higher_level_api/integration/queue_purge_spec.rb
@@ -1,4 +1,4 @@
-describe "Any queue" do
+RSpec.describe "Any queue" do
 
   #
   # Environment

--- a/spec/higher_level_api/integration/queue_unbind_spec.rb
+++ b/spec/higher_level_api/integration/queue_unbind_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-
-
 describe "Any queue" do
 
   #

--- a/spec/higher_level_api/integration/queue_unbind_spec.rb
+++ b/spec/higher_level_api/integration/queue_unbind_spec.rb
@@ -1,4 +1,4 @@
-describe "Any queue" do
+RSpec.describe "Any queue" do
 
   #
   # Environment

--- a/spec/higher_level_api/integration/sender_selected_distribution_spec.rb
+++ b/spec/higher_level_api/integration/sender_selected_distribution_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "Any AMQP 0.9.1 client using RabbitMQ" do
 
   #

--- a/spec/higher_level_api/integration/sender_selected_distribution_spec.rb
+++ b/spec/higher_level_api/integration/sender_selected_distribution_spec.rb
@@ -1,4 +1,4 @@
-describe "Any AMQP 0.9.1 client using RabbitMQ" do
+RSpec.describe "Any AMQP 0.9.1 client using RabbitMQ" do
 
   #
   # Environment

--- a/spec/higher_level_api/integration/tls_spec.rb
+++ b/spec/higher_level_api/integration/tls_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe "MarchHare.connect with TLS" do
 
   #

--- a/spec/higher_level_api/integration/tls_spec.rb
+++ b/spec/higher_level_api/integration/tls_spec.rb
@@ -1,4 +1,4 @@
-describe "MarchHare.connect with TLS" do
+RSpec.describe "MarchHare.connect with TLS" do
 
   #
   # Examples

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,7 +64,7 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  #config.warnings = true
+  config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  #config.disable_monkey_patching!
+  config.disable_monkey_patching!
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require 'bundler'
@@ -19,4 +17,79 @@ puts "Running on Ruby #{RUBY_VERSION}."
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!
+
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #config.disable_monkey_patching!
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  #config.warnings = true
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
This PR upgrades rspec to the latest 3.5 version, and then enables a number of rspec recommended optional features.

It then removes the need for a spec_helper, updates the specs not to use monkey patched versions of rspec methods, and fixes a number of ruby warnings.

Finally, it speeds up test suite execution by 15 seconds by lowering the `network_recovery_interval` in the connection spec.

Hope these are acceptable, and thanks for your work on the gem!