### PR TITLE
raise explicit error on create_channel failure

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -165,6 +165,14 @@ module MarchHare
            else
              @connection.create_channel
            end
+      if jc.nil?
+        error_message = <<-MSG
+          Unable to create a channel. This is likely due to having a channel_max setting
+          on the rabbitmq broker (see https://www.rabbitmq.com/configure.html).
+          There are currently #{@channels.size} channels on this connection.
+        MSG
+        raise ::MarchHare::ChannelError.new(error_message, false)
+      end
 
       ch = Channel.new(self, jc)
       register_channel(ch)


### PR DESCRIPTION
This addresses #98

If creating a channel fails for some reason this will raise a `ChannelError` with a verbose error message like:

```
MarchHare::ChannelError:           Unable to create a channel. This is likely due to having a channel_max setting
          on the rabbitmq broker (see https://www.rabbitmq.com/configure.html).
          There are currently 200 channels on this connection.

	from /Users/mmmries/code/march_hare/lib/march_hare/session.rb:174:in `create_channel'
	from (irb):11:in `<eval>'
```

The current behavior is to pass the `nil` down into the channel initializer where it later fails with an error message like:

```
NoMethodError: undefined method `add_shutdown_listener' for nil:NilClass
                    on_shutdown at /srv/bunyan/shared/bundle/jruby/2.3.0/gems/march_hare-2.18.0-java/lib/march_hare/channel.rb:183
                     initialize at /srv/bunyan/shared/bundle/jruby/2.3.0/gems/march_hare-2.18.0-java/lib/march_hare/channel.rb:135
                 create_channel at /srv/bunyan/shared/bundle/jruby/2.3.0/gems/march_hare-2.18.0-java/lib/march_hare/session.rb:169
```

/cc @michaelklishin @abrandoned