### PR TITLE
start a graceful shutdown on connection recovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 script: "bundle exec rspec -c spec"
 rvm:
-  - jruby-19mode
-  - jruby-9.0.0.0
+  - jruby-1.7.26
+  - jruby-9.1.5.0
 notifications:
   recipients:
     - michael@rabbitmq.com

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -507,6 +507,7 @@ module MarchHare
 
       converting_rjc_exceptions_to_ruby do
         if @executor_factory
+          @executor.shutdown() if @executor
           @executor = @executor_factory.call
           @cf.new_connection(@executor)
         else
@@ -520,6 +521,7 @@ module MarchHare
       @cf.uri = uri
       converting_rjc_exceptions_to_ruby do
         if @executor_factory
+          @executor.shutdown() if @executor
           @executor = @executor_factory.call
           @cf.new_connection(@executor)
         else

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -36,6 +36,7 @@ module MarchHare
     #
     # @param [Hash] options Connection options
     #
+    # @option options [Numeric] :executor_shutdown_timeout (30.0) when recovering from a network failure how long should we wait for the current threadpool to finish handling its messages
     # @option options [String] :host ("127.0.0.1") Hostname or IP address to connect to
     # @option options [Integer] :port (5672) Port RabbitMQ listens on
     # @option options [String] :username ("guest") Username
@@ -125,6 +126,8 @@ module MarchHare
       # executors cannot be restarted after shutdown,
       # so we really need a factory here. MK.
       @executor_factory = opts[:executor_factory] || build_executor_factory_from(opts)
+      # we expect this option to be specified in seconds
+      @executor_shutdown_timeout = opts.fetch(:executor_shutdown_timeout, 30.0)
 
       @hosts            = self.class.hosts_from(opts)
       @default_host_selection_strategy = lambda { |hosts| hosts.sample }
@@ -507,7 +510,7 @@ module MarchHare
 
       converting_rjc_exceptions_to_ruby do
         if @executor_factory
-          @executor.shutdown() if @executor
+          shut_down_executor_pool_and_await_timeout
           @executor = @executor_factory.call
           @cf.new_connection(@executor)
         else
@@ -521,7 +524,7 @@ module MarchHare
       @cf.uri = uri
       converting_rjc_exceptions_to_ruby do
         if @executor_factory
-          @executor.shutdown() if @executor
+          shut_down_executor_pool_and_await_timeout
           @executor = @executor_factory.call
           @cf.new_connection(@executor)
         else
@@ -533,6 +536,17 @@ module MarchHare
     # @private
     def maybe_shut_down_executor
       @executor.shutdown if defined?(@executor) && @executor
+    end
+
+    def shut_down_executor_pool_and_await_timeout
+      return unless @executor
+      ms_to_wait = (@executor_shutdown_timeout * 1000).to_i
+      @executor.shutdown()
+      unless @executor.awaitTermination(ms_to_wait, java.util.concurrent.TimeUnit::MILLISECONDS)
+        @executor.shutdownNow()
+      end
+    rescue java.lang.InterruptedException
+      #no op, just means we got a forced shutdown
     end
 
     # Makes it easier to construct executor factories.


### PR DESCRIPTION
An attempt to resolve #97 

I noticed this same problem in the form of a hanging travis build. My test suite includes an integration test where I force the connection to be closed via the management plugin and watch to make sure it reconnects and continues to receive messages from the broker.

Often times after my full suite ran the process would hang rather than exiting cleanly. This turned out to be because there was still a threadpool hanging around waiting for more work to do.

This fix initiates a graceful shutdown of the executor pool when a new connection is being established. There is no attempt to provide a timeout and a `shutDownNow()`, because as @michaelklishin mentioned in #97 we won't have any idea of how long we should wait around. Instead this just initiates a graceful shutdown and we hope for the best (ie the threads will complete or die before the process needs to exit). This is not an ideal implementation, but it resolves the common case for my usage where a connection reset might happen many hours before I actually shut down the process. That provides plenty of time for the threadpool to be cleaned up.

I would love to hear other ideas on a cleaner solution if anyone has them.

/cc @abrandoned @michaelklishin @ivoanjo 