### PR TITLE
Fix Exchange#publish docs to show timestamp as Time, not Integer

### DIFF
--- a/lib/march_hare/exchange.rb
+++ b/lib/march_hare/exchange.rb
@@ -57,7 +57,7 @@ module MarchHare
     # @option opts [Boolean] :mandatory Should the message be returned if it cannot be routed to any queue?
     # @option opts [Hash] :properties Messages and delivery properties
     #
-    #  * :timestamp (Integer) A timestamp associated with this message
+    #  * :timestamp (Time) A timestamp associated with this message
     #  * :expiration (Integer) Expiration time after which the message will be deleted
     #  * :type (String) Message type, e.g. what type of event or command this message represents. Can be any string
     #  * :reply_to (String) Queue name other apps should send the response to

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -539,7 +539,7 @@ module MarchHare
     end
 
     def shut_down_executor_pool_and_await_timeout
-      return unless @executor
+      return unless defined?(@executor) && @executor
       ms_to_wait = (@executor_shutdown_timeout * 1000).to_i
       @executor.shutdown()
       unless @executor.awaitTermination(ms_to_wait, java.util.concurrent.TimeUnit::MILLISECONDS)

--- a/spec/higher_level_api/integration/exchange_publish_spec.rb
+++ b/spec/higher_level_api/integration/exchange_publish_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe MarchHare::Exchange do
+  let(:connection) { MarchHare.connect }
+
+  after do
+    connection.close
+  end
+
+  it 'allows a message timestamp to be included when publishing a message' do
+    ch = connection.create_channel
+    queue = ch.queue('publish_spec', exclusive: true)
+    timestamp = Time.new(2016)
+
+    ch.default_exchange.publish(
+      'hello, world!',
+      routing_key: queue.name,
+      properties: {timestamp: timestamp},
+    )
+
+    expect(queue.get.first.properties.timestamp).to eq timestamp.to_java
+  end
+end

--- a/spec/higher_level_api/integration/exchange_publish_spec.rb
+++ b/spec/higher_level_api/integration/exchange_publish_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe MarchHare::Exchange do
 
   it 'allows a message timestamp to be included when publishing a message' do
     ch = connection.create_channel
+    ch.confirm_select
     queue = ch.queue('publish_spec', exclusive: true)
     timestamp = Time.new(2016)
 
@@ -16,6 +17,7 @@ RSpec.describe MarchHare::Exchange do
       properties: {timestamp: timestamp},
     )
 
+    expect(ch.wait_for_confirms).to be_truthy
     expect(queue.get.first.properties.timestamp).to eq timestamp.to_java
   end
 end


### PR DESCRIPTION
The underlying java ampq client is expecting a Date already, so let's document and pass timestamp as Time, as it's generally less error-prone than just passing it as an Integer.

(Also included a quick warning fix).

Fixes #102