### PR TITLE
Remove unused thread_pool

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -268,7 +268,6 @@ module MarchHare
           end
         end
       end
-      @thread_pool = ThreadPools.dynamically_growing
       self.recover_shutdown_hooks(new_connection)
 
       # sorting channels by id means that the cases like the following:


### PR DESCRIPTION
When in commit ea3c5ef0f1 march_hare's thread pools were deprecated in favor of RMQ's thread pools, one thread pool was left behind, but it is/was no longer used, and can be safely removed.

Fixes #96