### PR TITLE
Channel: Use Integer instead of Fixnum

### DIFF
--- a/lib/march_hare/channel.rb
+++ b/lib/march_hare/channel.rb
@@ -985,7 +985,7 @@ module MarchHare
     def guarding_against_stale_delivery_tags(tag, &block)
       case tag
       # if a fixnum was passed, execute unconditionally. MK.
-      when Fixnum then
+      when Integer then
         block.call
         # versioned delivery tags should be checked to avoid
         # sending out stale (invalid) tags after channel was reopened


### PR DESCRIPTION
Ruby 2.4.0 compatibility in JRuby means a warning about Fixnum.

(See https://github.com/jruby/jruby/issues/4293 for 2.4.0 compat updates. The " Fixnum and Bignum are unified into Integer Feature" is what this issue is about.)

See https://github.com/ruby-amqp/bunny/pull/458