### PR TITLE
Travis: use jruby-9.1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 script: "bundle exec rspec -c spec"
 rvm:
   - jruby-1.7.26
-  - jruby-9.1.6.0
+  - jruby-9.1.7.0
 notifications:
   recipients:
     - michael@rabbitmq.com


### PR DESCRIPTION
This PR changes the build matrix to use latest stable JRuby.