### PR TITLE
Travis: trust rspec's .rspec file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 before_script: "./bin/ci/before_build"
-script: "bundle exec rspec -c spec"
+script: "bundle exec rspec"
 rvm:
   - jruby-9.1.8.0
 notifications:


### PR DESCRIPTION
This PR tries to rely on the defaults set up in the `.rspec` file.