### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 
 script: "bundle exec rspec"
 rvm:
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
 
 notifications:
   recipients:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html