### PR TITLE
RFC: Configure all background threads as daemon threads by default

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -75,7 +75,12 @@ module MarchHare
       cf.requested_heartbeat = heartbeat_from(options)
       cf.connection_timeout  = connection_timeout_from(options) if include_connection_timeout?(options)
 
-      cf.thread_factory      = thread_factory_from(options)    if include_thread_factory?(options)
+      cf.thread_factory =
+        if include_thread_factory?(options)
+          thread_factory_from(options)
+        else
+          ThreadPools.daemon_thread_factory
+        end
       cf.exception_handler   = exception_handler_from(options) if include_exception_handler?(options)
 
       tls = (options[:ssl] || options[:tls])
@@ -566,7 +571,7 @@ module MarchHare
       # a callable that creates a fixed size executor
       # of that size. MK.
       if n = opts[:thread_pool_size]
-        return Proc.new { MarchHare::ThreadPools.fixed_of_size(n) }
+        proc { MarchHare::ThreadPools.fixed_of_size(n, use_daemon_threads: true) }
       end
     end
 

--- a/lib/march_hare/thread_pools.rb
+++ b/lib/march_hare/thread_pools.rb
@@ -6,27 +6,58 @@ module MarchHare
   class ThreadPools
     # Returns a new thread pool (JDK executor) of a fixed size.
     #
+    # @param [Integer] n Number of threads to use
+    #
+    # @option options [Boolean] :use_daemon_threads (false) Should new threads be marked as daemon?
+    #
     # @return A thread pool (JDK executor)
-    def self.fixed_of_size(n)
+    def self.fixed_of_size(n, use_daemon_threads: false)
       raise ArgumentError.new("n must be a positive integer!") unless Integer === n
       raise ArgumentError.new("n must be a positive integer!") unless n > 0
 
-      JavaConcurrent::Executors.new_fixed_thread_pool(n)
+      if use_daemon_threads
+        JavaConcurrent::Executors.new_fixed_thread_pool(n, &daemon_thread_factory)
+      else
+        JavaConcurrent::Executors.new_fixed_thread_pool(n)
+      end
     end
 
     # Returns a new thread pool (JDK executor) of a fixed size of 1.
     #
+    # @option options [Boolean] :use_daemon_threads (false) Should new threads be marked as daemon?
+    #
     # @return A thread pool (JDK executor)
-    def self.single_threaded
-      JavaConcurrent::Executors.new_single_thread_executor
+    def self.single_threaded(use_daemon_threads: false)
+      if use_daemon_threads
+        JavaConcurrent::Executors.new_single_thread_executor(&daemon_thread_factory)
+      else
+        JavaConcurrent::Executors.new_single_thread_executor
+      end
     end
 
     # Returns a new thread pool (JDK executor) that will create new
     # threads as needed.
     #
+    # @option options [Boolean] :use_daemon_threads (false) Should new threads be marked as daemon?
+    #
     # @return A thread pool (JDK executor)
-    def self.dynamically_growing
-      JavaConcurrent::Executors.new_cached_thread_pool
+    def self.dynamically_growing(use_daemon_threads: false)
+      if use_daemon_threads
+        JavaConcurrent::Executors.new_cached_thread_pool(&daemon_thread_factory)
+      else
+        JavaConcurrent::Executors.new_cached_thread_pool
+      end
+    end
+
+    # Returns a new thread factory that creates daemon threads.
+    #
+    # @option options [ThreadFactory] :base_factory Upstream thread factory used to create threads
+    #
+    # @return A thread factory
+    def self.daemon_thread_factory(base_factory: JavaConcurrent::Executors.default_thread_factory)
+      proc { |runnable|
+        base_factory.new_thread(runnable).tap { |t| t.daemon = true }
+      }
     end
   end
 end


### PR DESCRIPTION
Java/JVM threads introduce the concept of daemon threads: any thread can either be non-daemon or daemon.

As discussed in https://stackoverflow.com/questions/2213340/what-is-daemon-thread-in-java the difference between both is only at JVM exit: the JVM exits when all non-daemon threads terminate. When the last non-daemon thread finishes its work and terminates, the JVM will shut down, and any remaining daemon threads are just ignored.

By default, march_hare either relies on the ampq-client to create its own threads and pools or it supplies its own pools. In both of these cases, all the created threads are non-daemon, that is, they block the JVM exit until they finish. This means that if you start a march_hare connection or consumer, and don't call #close on it, the JVM won't exit, even if there's nothing else to do.

On the Ruby side, the concept of daemon/non-daemon threads does not exist. On MRI, when the first thread created on the system dies, the system exits.

This creates an expectation mismatch when rubyists start using march_hare: suddenly their applications just "hang" when exiting, without any clear reason why.

This happens a lot on @Talkdesk as we move more and more of our systems from bunny to march_hare: in many cases, our connections are long-lived singletons and thus we never closed them, but suddenly things like our test suites or our rake tasks just "hang" if for some reason they cause a rabbimq connection to be started but just throw away the reference without closing the connection when they don't need it anymore.

This issue is so common that it made it to our internal JRuby FAQ. I've also seen it in questions such as https://github.com/ruby-amqp/march_hare/issues/97#issuecomment-302388621

To solve this challenge, this PR changes march_hare to behave like MRI/bunny, and use daemon threads by default for all background work.
This way examples such as:

```ruby
require 'march_hare'

con = MarchHare.connect(
    automatic_recovery: false,
    uri: 'amqp://guest:guest@localhost',
)
```

no longer hang the JVM, and instead exit cleanly.

Users that want the existing behavior can still supply their own thread pools as they've always could, and the defaults for manually-created MarchHare#ThreadPools are also unchanged.

I'm opening this as a "Request for Comments" as this still changes the default behavior, but I really believe this will save a lot of head-scratching for a lot of library users.