### PR TITLE
Support creating thread factories & pools that use daemon threads

### DIFF
--- a/lib/march_hare/thread_pools.rb
+++ b/lib/march_hare/thread_pools.rb
@@ -6,27 +6,58 @@ module MarchHare
   class ThreadPools
     # Returns a new thread pool (JDK executor) of a fixed size.
     #
+    # @param [Integer] n Number of threads to use
+    #
+    # @option options [Boolean] :use_daemon_threads (false) Should new threads be marked as daemon?
+    #
     # @return A thread pool (JDK executor)
-    def self.fixed_of_size(n)
+    def self.fixed_of_size(n, use_daemon_threads: false)
       raise ArgumentError.new("n must be a positive integer!") unless Integer === n
       raise ArgumentError.new("n must be a positive integer!") unless n > 0
 
-      JavaConcurrent::Executors.new_fixed_thread_pool(n)
+      if use_daemon_threads
+        JavaConcurrent::Executors.new_fixed_thread_pool(n, &daemon_thread_factory)
+      else
+        JavaConcurrent::Executors.new_fixed_thread_pool(n)
+      end
     end
 
     # Returns a new thread pool (JDK executor) of a fixed size of 1.
     #
+    # @option options [Boolean] :use_daemon_threads (false) Should new threads be marked as daemon?
+    #
     # @return A thread pool (JDK executor)
-    def self.single_threaded
-      JavaConcurrent::Executors.new_single_thread_executor
+    def self.single_threaded(use_daemon_threads: false)
+      if use_daemon_threads
+        JavaConcurrent::Executors.new_single_thread_executor(&daemon_thread_factory)
+      else
+        JavaConcurrent::Executors.new_single_thread_executor
+      end
     end
 
     # Returns a new thread pool (JDK executor) that will create new
     # threads as needed.
     #
+    # @option options [Boolean] :use_daemon_threads (false) Should new threads be marked as daemon?
+    #
     # @return A thread pool (JDK executor)
-    def self.dynamically_growing
-      JavaConcurrent::Executors.new_cached_thread_pool
+    def self.dynamically_growing(use_daemon_threads: false)
+      if use_daemon_threads
+        JavaConcurrent::Executors.new_cached_thread_pool(&daemon_thread_factory)
+      else
+        JavaConcurrent::Executors.new_cached_thread_pool
+      end
+    end
+
+    # Returns a new thread factory that creates daemon threads.
+    #
+    # @option options [ThreadFactory] :base_factory Upstream thread factory used to create threads
+    #
+    # @return A thread factory
+    def self.daemon_thread_factory(base_factory: JavaConcurrent::Executors.default_thread_factory)
+      proc { |runnable|
+        base_factory.new_thread(runnable).tap { |t| t.daemon = true }
+      }
     end
   end
 end


### PR DESCRIPTION
Java/JVM threads introduce the concept of daemon threads: any thread can either be non-daemon or daemon.

As discussed in https://stackoverflow.com/questions/2213340/what-is-daemon-thread-in-java the difference between both is only at JVM exit: the JVM exits when all non-daemon threads terminate. When the last non-daemon thread finishes its work and terminates, the JVM will shut down, and any remaining daemon threads are just ignored.

By default, march_hare either relies on the ampq-client to create its own threads and pools or it supplies its own pools. In both of these cases, all the created threads are non-daemon, that is, they block the JVM exit until they finish. This means that if you start a march_hare connection or consumer, and don't call #close on it, the JVM won't exit, even if there's nothing else to do.

On the Ruby side, the concept of daemon/non-daemon threads does not exist. On MRI, when the first thread created on the system dies, the system exits.

This creates an expectation mismatch when rubyists start using march_hare: suddenly their applications just "hang" when exiting, without any clear reason why.

This happens a lot on @Talkdesk as we move more and more of our systems from bunny to march_hare: in many cases, our connections are long-lived singletons and thus we never closed them, but suddenly things like our test suites or our rake tasks just "hang" if for some reason they cause a rabbimq connection to be started but just throw away the reference without closing the connection when they don't need it anymore.

This issue is so common that it made it to our internal JRuby FAQ. I've also seen it in questions such as https://github.com/ruby-amqp/march_hare/issues/97#issuecomment-302388621

To facilitate the use of march_hare using daemon threads instead of the default non-daemon threads, this commit adds the option of creating thread factories and pools that make use of daemon threads to the MarchHare::ThreadPools class.

To configure MarchHare to use daemon threads, you can then do:

```ruby
require 'march_hare'

connection = MarchHare.connect(
  uri: 'amqp://guest:guest@localhost',
  thread_factory: MarchHare::ThreadPools.daemon_thread_factory,
  executor_factory: proc {
    MarchHare::ThreadPools.fixed_of_size(10, use_daemon_threads: true)
  },
)
```

The `thread_factory` is used by the underlying Java client to create new threads to handle connections, and the optional `executor_factory` can be used to get even more control on the number and allocation rules used by the thread pool.