### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 
 script: "bundle exec rspec"
 rvm:
-  - jruby-9.1.13.0
+  - jruby-9.1.15.0
 
 notifications:
   recipients:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html