### PR TITLE
Added handling of java.util.concurrent.TimeoutException

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -500,6 +500,8 @@ module MarchHare
         raise ConnectionRefused.new("Connection to #{@cf.host}:#{@cf.port} refused: host unknown")
       rescue java.net.SocketException => e
         raise ConnectionRefused.new("Connection to #{@cf.host}:#{@cf.port} failed")
+      rescue java.util.concurrent.TimeoutException => e
+        raise ConnectionRefused.new("Connection to #{@cf.host}:#{@cf.port} failed: timeout")
       rescue com.rabbitmq.client.AuthenticationFailureException => e
         raise AuthenticationFailureError.new(@cf.username, @cf.virtual_host, @cf.password.bytesize)
       rescue com.rabbitmq.client.PossibleAuthenticationFailureException => e


### PR DESCRIPTION
I was running into this on my local RabbitMQ server for some reason. Getting the info about which host and port it tries to use is helpful when debugging.