### PR TITLE
Session should connect using the :port option when :host is used

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -402,7 +402,14 @@ module MarchHare
 
     # @private
     def self.adresses_from(options)
-      options[:addresses] || options[:hosts] || [hostname_from(options)]
+      options[:addresses] || options[:hosts] || [address_with_port(options)]
+    end
+
+    # @private
+    def self.address_with_port(options)
+      address = hostname_from(options)
+      address = "#{address}:#{options[:port]}" if options[:port]
+      address
     end
 
     # @private

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -402,11 +402,11 @@ module MarchHare
 
     # @private
     def self.adresses_from(options)
-      options[:addresses] || options[:hosts] || [address_with_port(options)]
+      options[:addresses] || options[:hosts] || [address_with_port_from(options)]
     end
 
     # @private
-    def self.address_with_port(options)
+    def self.address_with_port_from(options)
       address = hostname_from(options)
       address = "#{address}:#{options[:port]}" if options[:port]
       address

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -78,6 +78,16 @@ RSpec.describe "MarchHare.connect" do
     c.close
   end
 
+  it "lets you specify host and port" do
+    expect {
+      MarchHare.connect(host: "127.0.0.1", port: 35672, network_recovery_interval: 0)
+    }.to raise_error(MarchHare::ConnectionRefused)
+
+    c = MarchHare.connect(host: "127.0.0.1", port: 5672, network_recovery_interval: 0)
+    expect(c).to be_connected
+    c.close
+  end
+
   it "lets you specify multiple hosts" do
     c = MarchHare.connect(hosts: ["127.0.0.1"], network_recovery_interval: 0)
     expect(c).to be_connected


### PR DESCRIPTION
I found that the port being passed in was not being used. I am a first-time contributor, let me know if you need anything changed.