### PR TITLE
Travis: use latest JRuby 9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 
 script: "bundle exec rspec"
 rvm:
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
 
 notifications:
   recipients:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)