### PR TITLE
Blocked connection state machine

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -178,6 +178,7 @@ module MarchHare
       @network_recovery_interval = opts.fetch(:network_recovery_interval, DEFAULT_NETWORK_RECOVERY_INTERVAL)
       @shutdown_hooks            = Array.new
       @blocked_connection_hooks  = Array.new
+      @connection_recovery_hooks = Array.new
 
       if @automatically_recover
         self.add_automatic_recovery_hook
@@ -273,6 +274,20 @@ module MarchHare
       @connection.clear_blocked_listeners
     end
 
+    def on_recovery_start(&block)
+      listener = RecoveryListener.for_start(block)
+      @connection_recovery_hooks << listener
+    end
+
+    def on_recovery(&block)
+      listener = RecoveryListener.for_finish(block)
+      @connection_recovery_hooks << listener
+    end
+
+    # Clears all callbacks defined with #on_recovery_started and #on_recovery
+    def clear_connection_recovery_callbacks
+      @connection_recovery_hooks.clear
+    end
 
     # @private
     def add_automatic_recovery_hook
@@ -299,6 +314,8 @@ module MarchHare
     # to recover from network failures)
     def automatically_recover
       @logger.debug("session: begin automatic connection recovery")
+
+      fire_recovery_start_hooks
 
       ms = @network_recovery_interval * 1000
       # recovering immediately makes little sense. Wait a bit first. MK.
@@ -331,6 +348,10 @@ module MarchHare
       end
 
       @connection = new_connection
+
+      fire_recovery_hooks
+
+      @connection
     end
 
     # @private
@@ -658,6 +679,20 @@ module MarchHare
       end
     end
 
+    # @private
+    def fire_recovery_start_hooks
+      @connection_recovery_hooks.each do |recovery_listener|
+        recovery_listener.handle_recovery_started(self)
+      end
+    end
+
+    # @private
+    def fire_recovery_hooks
+      @connection_recovery_hooks.each do |recovery_listener|
+        recovery_listener.handle_recovery(self)
+      end
+    end
+
     # Ruby blocks-based BlockedListener that handles
     # connection.blocked and connection.unblocked.
     # @private
@@ -696,5 +731,32 @@ module MarchHare
       end
     end
 
+    # Ruby blocks-based RecoveryListener that handles
+    # connection recovery_started and recovery
+    class RecoveryListener
+      NOOP_FN1 = Proc.new { |_| }
+      private_constant :NOOP_FN1
+
+      def self.for_start(block)
+        new(block, NOOP_FN1)
+      end
+
+      def self.for_finish(block)
+        new(NOOP_FN1, block)
+      end
+
+      def initialize(before_recovery, after_recovery)
+        @recovery_start_hook = before_recovery
+        @recovery_hook = after_recovery
+      end
+
+      def handle_recovery_started(recoverable)
+        @recovery_start_hook.call(recoverable)
+      end
+
+      def handle_recovery(recoverable)
+        @recovery_hook.call(recoverable)
+      end
+    end
   end
 end

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -298,4 +298,37 @@ RSpec.describe "Connection recovery" do
       c.close
     end
   end
+
+  it 'fires on_recovery_start hooks' do
+    with_open do |c|
+      recovery_start_hook_called = false
+      c.on_recovery_start do |session|
+        recovery_start_hook_called = true
+        expect(session).to eq(c)
+      end
+
+      close_all_connections!
+
+      wait_for_recovery
+
+      expect(recovery_start_hook_called).to be true
+    end
+  end
+
+  it 'fires on_recovery hooks' do
+    with_open do |c|
+      recovery_hook_called = false
+
+      c.on_recovery do |session|
+        recovery_hook_called = true
+        expect(session).to eq(c)
+      end
+
+      close_all_connections!
+
+      wait_for_recovery
+
+      expect(recovery_hook_called).to be true
+    end
+  end
 end


### PR DESCRIPTION
This PR attempts to port functionality from the upstream Java client that enables a consumer to maintain a state machine of connection blocked/unblocked status with automatic recovery enabled; it does so in two ways:

1. ensures connection blocked/unblocked hooks survive connection recovery (resolving #141)
2. since the ruby `Session` implementation performs its own connection recovery by replacing the underlying connection (and the new connection may be in either a blocked/unblocked state before we can register the hooks), this PR adds `Session#on_recovery_started` and `Session#on_recovery`, mirroring the hooks that are available on `com.rabbitmq.client.RecoverableConnection` in a ruby-style.

***

NOTE: I've had some trouble getting the specs in `connection_recovery_spec.rb` to run reliably; although we validate that the channels, queues, etc., are still connected after we attempt to destroy the underlying connection, they succeed whether we had a successful recovery or failed to kill the connection. This makes my added specs "flaky", since they _only_ succeed if the connection was successfully recovered.