### PR TITLE
CI: Use jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 
 script: "bundle exec rspec"
 rvm:
-  - jruby-9.2.7.0
+  - jruby-9.2.8.0
 
 notifications:
   recipients:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)