### PR TITLE
Fix port to be in valid range

### DIFF
--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "MarchHare.connect" do
   context "when connection fails due to RabbitMQ node not running" do
     it "raises an exception" do
       expect {
-        MarchHare.connect(hostname: "localhost", port: 77668)
+        MarchHare.connect(hostname: "localhost", port: 65534)
       }.to raise_error(MarchHare::ConnectionRefused)
     end
   end


### PR DESCRIPTION
Test was failing because "java.lang.IllegalArgumentException: port out of range:77668" exception being raised rather than expected ConnectionRefused.  Changing port to be in valid socket range.