### PR TITLE
F/support ssl rmq instance

### DIFF
--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -103,8 +103,7 @@ module MarchHare
             kmf.init(ks, pwd)
 
             if options[:trust_manager]
-              tm_a = options[:trust_manager].kind_of?(Array) ? options[:trust_manager] : [options[:trust_manager]]
-              ctx.init(kmf.get_key_managers, tm_a, nil)
+              ctx.init(kmf.get_key_managers, Array(options[:trust_manager]), nil)
             else
               # use the key store as the trust store
               tmf = TrustManagerFactory.get_instance(TrustManagerFactory.getDefaultAlgorithm());

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -103,7 +103,8 @@ module MarchHare
             kmf.init(ks, pwd)
 
             if options[:trust_manager]
-              ctx.init(kmf.get_key_managers, [options[:trust_manager]], nil)
+	      tm_a = options[:trust_manager].kind_of?(Array) ? options[:trust_manager] : [options[:trust_manager]]
+              ctx.init(kmf.get_key_managers, tm_a, nil)
             else
               # use the key store as the trust store
               tmf = TrustManagerFactory.get_instance(TrustManagerFactory.getDefaultAlgorithm());
@@ -111,6 +112,7 @@ module MarchHare
               ctx.init(kmf.get_key_managers, tmf.getTrustManagers(), nil)
             end
 
+            cf.set_sasl_config(options[:sasl_config]) if options[:sasl_config]
             cf.use_ssl_protocol(ctx)
           rescue Java::JavaLang::Throwable => e
             message = e.message

--- a/lib/march_hare/session.rb
+++ b/lib/march_hare/session.rb
@@ -103,7 +103,7 @@ module MarchHare
             kmf.init(ks, pwd)
 
             if options[:trust_manager]
-	      tm_a = options[:trust_manager].kind_of?(Array) ? options[:trust_manager] : [options[:trust_manager]]
+              tm_a = options[:trust_manager].kind_of?(Array) ? options[:trust_manager] : [options[:trust_manager]]
               ctx.init(kmf.get_key_managers, tm_a, nil)
             else
               # use the key store as the trust store


### PR DESCRIPTION
Check options[:trust_manager] as Array, and only wrap if necessary.  Add support for options[:sasl_config] if set.