### PR TITLE
stop reconnect_on_network_failure rescue/retry loop on session#close

### DIFF
--- a/lib/march_hare/exceptions.rb
+++ b/lib/march_hare/exceptions.rb
@@ -16,6 +16,12 @@ module MarchHare
   class ConnectionRefused < NetworkException
   end
 
+  class ConnectionClosedException < Exception
+    def initialize(message='')
+      super("Connection was explicitly closed and cannot be reopened. Create a new Connection instead. #{message}")
+    end
+  end
+
   class ChannelLevelException < Exception
     attr_reader :channel_close
 

--- a/spec/higher_level_api/integration/connection_recovery_spec.rb
+++ b/spec/higher_level_api/integration/connection_recovery_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Connection recovery" do
 
   def close_all_connections!
     # wait for stats to refresh, make sure to run bin/ci/before_build.sh as well!
-    sleep 0.7
+    sleep 1.7
     http_client.list_connections.each do |conn_info|
       puts "Closing connection #{conn_info.name}..."
       http_client.close_connection(conn_info.name)

--- a/spec/higher_level_api/integration/connection_spec.rb
+++ b/spec/higher_level_api/integration/connection_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe "MarchHare.connect" do
     end
   end
 
+  context "when connection manually closed" do
+    it "raises an exception on #automatically_recover" do
+      c = MarchHare.connect(uri: "amqp://127.0.0.1")
+      c.close
+      expect {
+        c.automatically_recover
+      }.to raise_error(MarchHare::ConnectionClosedException)
+    end
+  end
+
   it "handles amqp:// URIs w/o path part" do
     c = MarchHare.connect(uri: "amqp://127.0.0.1")
 
@@ -61,7 +71,7 @@ RSpec.describe "MarchHare.connect" do
     end
     c = MarchHare.connect(executor_factory: factory, network_recovery_interval: 0)
     c.close
-    c.automatically_recover
+    c.reopen
     c.close
     expect(calls).to eq(2)
   end
@@ -72,7 +82,7 @@ RSpec.describe "MarchHare.connect" do
     expect(c).to be_connected
     c.close
     expect(c).not_to be_connected
-    c.automatically_recover
+    c.reopen
     sleep 0.5
     expect(c).to be_connected
     c.close
@@ -93,7 +103,7 @@ RSpec.describe "MarchHare.connect" do
     expect(c).to be_connected
     c.close
     expect(c).not_to be_connected
-    c.automatically_recover
+    c.reopen
     sleep 0.5
     expect(c).to be_connected
     c.close
@@ -104,7 +114,7 @@ RSpec.describe "MarchHare.connect" do
     expect(c).to be_connected
     c.close
     expect(c).not_to be_connected
-    c.automatically_recover
+    c.reopen
     sleep 0.5
     expect(c).to be_connected
     c.close


### PR DESCRIPTION
I noticed that sometimes our processes get stuck on shutdown after we call `close` on the MarchHare::Session

While debugging this I noticed that this happens during a network outage because in this case march_hare is "stuck" in a never stopping rescue/retry loop in `reconnecting_on_network_failures`.

To solve this I now track if `close` was called and if so exit the automatic_recovery.

Honestly not entirely sure how to automatically test this. I'm able to manually reproduce this issue and that this fixes it but not sure I can make a spec out of this because it somewhat involves killing rabbitmq.