### PR TITLE
CI: Use JRuby 9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 
 script: "bundle exec rspec"
 rvm:
-  - jruby-9.2.15.0
+  - jruby-9.2.16.0
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 
 script: "bundle exec rspec"
 rvm:
-  - jruby-9.2.9.0
+  - jruby-9.2.15.0
 
 notifications:
   recipients:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.15.0**.

[JRuby 9.2.15.0 release blog post](https://www.jruby.org/2021/02/24/jruby-9-2-15-0.html)