### PR TITLE
gemspec: Remove unused directives

### DIFF
--- a/march_hare.gemspec
+++ b/march_hare.gemspec
@@ -15,10 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{RabbitMQ client for JRuby built around the official RabbitMQ Java client}
   s.description = %q{RabbitMQ client for JRuby built around the official RabbitMQ Java client}
 
-  s.rubyforge_project = 'march_hare'
-
   s.files         = `git ls-files -- lib`.split("\n")
-  s.test_files    = `git ls-files -- {spec}/*`.split("\n")
 
   s.require_paths = %w(lib)
 end


### PR DESCRIPTION
RubyForge closed a long time ago, and RubyGems.org does nothing special with the test_files directive.

---

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property

[1]: https://twitter.com/evanphx/status/399552820380053505