### PR TITLE
CI: Update to latest-released versions

### DIFF
--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -22,15 +22,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['jruby-9.2.19.0', 'jruby-9.3.0.0', 'jruby-head']
+        ruby-version:
+          - jruby-9.2
+          - jruby-9.3
+          - jruby-head
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
-    # uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
setup-ruby will pick from its list of "newest matching release for that prefix".

Example, for this run's jruby-9.2, we get:

<img width="797" alt="bild" src="https://user-images.githubusercontent.com/211/150021259-3496b8dc-3c33-41f4-b2f9-13837e0339d6.png">


Also: Drop some YAML comments that seemed unnecessary.